### PR TITLE
added prePath util, in order to sanitize paths before routing

### DIFF
--- a/src/middlewares/http.js
+++ b/src/middlewares/http.js
@@ -4,6 +4,13 @@
 
 'use strict';
 module.exports = function(restify, server, logger) {
+
+  /**************************************
+    Sanitize Path
+  **************************************/
+  var sanitize = require('../utils/prePath');
+  server.pre(sanitize());
+
   /*************************************
     Allows you to add in handlers
     that run before routing occurs

--- a/src/utils/prePath.js
+++ b/src/utils/prePath.js
@@ -1,0 +1,66 @@
+'use strict';
+
+/*************************************
+  SanitizePath
+**************************************/
+
+
+/**
+ * Cleans up sloppy URLs on the request object, like /foo////bar/// to /foo/bar.
+ * @private
+ * @function strip
+ * @param    {Object} path a url path to clean up
+ * @returns  {String}
+ */
+
+/* jshint ignore:start */
+
+function strip(path) {
+    var cur;
+    var next;
+    var str = '';
+
+    for (var i = 0; i < path.length; i++) {
+        cur = path.charAt(i);
+
+        if (i !== path.length - 1) {
+            next = path.charAt(i + 1);
+        }
+
+        if (cur === '/' && (next === '/' || (next === '?' && i > 0))) {
+            continue;
+        }
+
+        str += cur;
+    }
+
+    return (str);
+}
+
+
+/**
+ * @public
+ * @function sanitizePath
+ * @param    {Object}   options an options object
+ * @returns  {Function}
+ */
+
+
+
+function sanitizePath(options) {
+
+    function _sanitizePath(req, res, next) {
+        req.url = strip(req.url);
+        next();
+    }
+
+    return (_sanitizePath);
+}
+
+
+
+///--- Exports
+
+module.exports = sanitizePath;
+
+/* jshint ignore:end */

--- a/test/integration/specs/queryParams.test.js
+++ b/test/integration/specs/queryParams.test.js
@@ -8,7 +8,7 @@ var request = require('supertest'),
 chai.use(chaiAsPromised);
 
 function test(server) {
-  describe.only('Query params', function() {
+  describe('Query params', function() {
     var phrase = {
       id: 'testdomain!queryparams',
       url: 'queryparams',
@@ -48,6 +48,17 @@ function test(server) {
           expect(response).to.be.an('object');
           expect(response.body.id).to.equals('20');
           expect(response.body.name).to.equals('Harkonnen');
+          done(err);
+        });
+    });
+
+    it('executes the phrase correctly a second time without query params and / in the end.', function(done) {
+      this.timeout(30000);
+      request(server.app)
+        .get('/testdomain/queryparams/')
+        .expect(200)
+        .end(function(err, response) {
+          expect(response).to.be.an('object');
           done(err);
         });
     });


### PR DESCRIPTION
Cleans up sloppy URLs on the request object, like /foo////bar/// to /foo/bar