### PR TITLE
- Fixed newrelic transaction timing

### DIFF
--- a/newrelic.js
+++ b/newrelic.js
@@ -22,10 +22,8 @@ exports.config = {
      */
     level: 'trace'
   },
-  rules: {
-    ignore: ['.*Restify.*']
-  },
   transaction_tracer: {
     enabled: true
-  }
+  },
+  enforce_backstop: false
 }

--- a/src/utils/proxify.js
+++ b/src/utils/proxify.js
@@ -1,0 +1,28 @@
+'use strict'
+
+function proxifyFunction (obj, prop, f) {
+  prop.reduce(function (obj, property) {
+    if (!obj[property]) throw new Error('Property does not exists in obj: ' + property)
+    return obj[property]
+  }, obj)
+  var objToProxify = getFunctionContainer(obj, prop)
+  var functionToProxify = prop[prop.length - 1]
+  if (!f && Object.prototype.toString.call(f) === '[object Function]') throw new Error('Proxy property is not a function')
+  var currentObjFuncDef = objToProxify[functionToProxify]
+  objToProxify[functionToProxify] = f.bind(objToProxify, currentObjFuncDef)
+}
+
+function getFunctionContainer (obj, props) {
+  var currentProps = props.map(function (item) {
+    return item
+  })
+  currentProps.pop()
+  return currentProps.reduce(function (obj, property) {
+    if (!obj[property]) throw new Error('Property does not exists in obj: ' + property)
+    return obj[property]
+  }, obj)
+}
+
+module.exports = {
+  'proxifyFunction': proxifyFunction
+}


### PR DESCRIPTION
	- While working with custom transactions, we've noticed of a bad transaction time in the reports
	- There's a method in new relic api that can fake total duration time of the transaction